### PR TITLE
fix: update GitHub Copilot extension to stable version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,10 +9,11 @@
     "customizations": {
         "vscode": {
         "extensions": [
-            "github.copilot@insiders", // GitHub Copilot + Copilot Chat insiders
+            "github.copilot", // GitHub Copilot + Copilot Chat
             "markdown-lint.markdownlinter",
             "ms-python.python", // Python extension
-            "ms-python.vscode-pylance" // Pylance extension for Python
+            "ms-python.vscode-pylance", // Pylance extension for Python
+            "ms-python.debugpy" // Debugpy extension for Python
         ],
         "settings": {
             "chat.agent.enabled": true,


### PR DESCRIPTION
This pull request makes a small update to the list of recommended VS Code extensions in the `.devcontainer/devcontainer.json` file. The change removes the Copilot Insiders extension in favor of the standard Copilot extension and adds the Debugpy extension for Python development.