### PR TITLE
fix: refine setup instructions for Django REST Framework and remove r…

### DIFF
--- a/.github/steps/4-setup-django-rest-framework.md
+++ b/.github/steps/4-setup-django-rest-framework.md
@@ -26,10 +26,8 @@ Copy and paste the following prompt(s) in the GitHub Copilot Chat and select the
 > ```prompt
 > Let's setup codespace for the URL, start the server via VS Code launch.json, and test the API.
 > 
-> 1. create an environment variable OCTOFIT_API_BASE_URL to use [REPLACE-THIS-WITH-YOUR-CODESPACE-NAME]-8000.app.github.dev for the api endpoints in settings.py, urls.py, and views.py
-> 2. Update views.py and urls.py to replace the return for the REST API URL endpoints with the environment variable OCTOFIT_API_BASE_URL https://{OCTOFIT_API_BASE_URL}-8000.app.github.dev for Django and avoid certificate HTTPS issues.
 > 1. Create an environment variable `OCTOFIT_API_BASE_URL` with the value `[REPLACE-THIS-WITH-YOUR-CODESPACE-NAME]-8000.app.github.dev` for use in your API endpoints in `settings.py`, `urls.py`, and `views.py`.
-> 2. Update `views.py` and `urls.py` to use the value of the environment variable `OCTOFIT_API_BASE_URL` in your REST API URL endpoints (e.g., `https://${OCTOFIT_API_BASE_URL}`) for Django, to avoid certificate HTTPS issues.
+> 2. Update `urls.py` to use the value of the environment variable `OCTOFIT_API_BASE_URL` in your REST API URL endpoints (e.g., `https://${OCTOFIT_API_BASE_URL}`) for Django, to avoid certificate HTTPS issues.
 > 3. Make sure the Django backend works on your codespace URL (i.e., the value of `OCTOFIT_API_BASE_URL`) by updating `ALLOWED_HOSTS` in `octofit-tracker/backend/octofit_tracker/settings.py`.
 > 4. Test the API endpoints using curl command.
 >```

--- a/.github/workflows/4-setup-django-rest-framework.yml
+++ b/.github/workflows/4-setup-django-rest-framework.yml
@@ -69,16 +69,6 @@ jobs:
           case-sensitive: false
 
       - name: Check for codespace url has been added to views.py
-        id: check-codespace-url-views
-        continue-on-error: true
-        uses: skills/action-keyphrase-checker@v1
-        with:
-          text-file: octofit-tracker/backend/octofit_tracker/views.py
-          keyphrase: '-8000.app.github.dev'
-          minimum-occurrences: 1
-          case-sensitive: false
-
-      - name: Check for codespace url has been added to views.py
         id: check-codespace-url-urls
         continue-on-error: true
         uses: skills/action-keyphrase-checker@v1
@@ -101,8 +91,6 @@ jobs:
             results_table:
               - description: "Check settings.py for codespace URL"
                 passed: ${{ steps.check-codespace-url-settings.outcome == 'success' }}
-              - description: "Check views.py for codespace URL"
-                passed: ${{ steps.check-codespace-url-views.outcome == 'success' }}
               - description: "Check urls.py for codespace URL"
                 passed: ${{ steps.check-codespace-url-urls.outcome == 'success' }}
 


### PR DESCRIPTION
This pull request updates the Django REST framework setup instructions and the associated GitHub Actions workflow to remove the requirement for adding the codespace URL to `views.py`. The focus is now on configuring the codespace URL in `urls.py` and related files, simplifying the setup process and workflow checks.