### PR TITLE
fix: remove redundant mongodb-clients installation in post_create.sh

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -7,4 +7,3 @@ echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb
 sudo apt-get update
 sudo apt-get install -y python3-venv
 sudo apt-get install -y mongodb-org
-sudo apt-get install -y mongodb-clients


### PR DESCRIPTION
This pull request makes a minor adjustment to the development container setup script by removing the installation of the `mongodb-clients` package. This change helps streamline the dependencies installed during the post-create process.

