### PR TITLE
fix: remove redundant check step from copilot GitHub workflow

### DIFF
--- a/.github/workflows/6-copilot-on-github.yml
+++ b/.github/workflows/6-copilot-on-github.yml
@@ -22,52 +22,6 @@ jobs:
     name: Find Exercise Issue
     uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.7.0
 
-  check_step_work:
-    name: Check step work
-    runs-on: ubuntu-latest
-    needs: [find_exercise]
-    env:
-      ISSUE_REPOSITORY: ${{ github.repository }}
-      ISSUE_NUMBER: ${{ needs.find_exercise.outputs.issue-number }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Get response templates
-        uses: actions/checkout@v4
-        with:
-          repository: skills/exercise-toolkit
-          path: exercise-toolkit
-          ref: v0.7.0
-
-      - name: Find last comment
-        id: find-last-comment
-        uses: peter-evans/find-comment@v3
-        with:
-          repository: ${{ env.ISSUE_REPOSITORY }}
-          issue-number: ${{ env.ISSUE_NUMBER }}
-          direction: last
-
-      - name: Update comment - checking work
-        uses: GrantBirki/comment@v2.1.1
-        with:
-          repository: ${{ env.ISSUE_REPOSITORY }}
-          issue-number: ${{ env.ISSUE_NUMBER }}
-          comment-id: ${{ steps.find-last-comment.outputs.comment-id }}
-          file: exercise-toolkit/markdown-templates/step-feedback/checking-work.md
-          edit-mode: replace
-
-      # START: Check practical exercise
-
-      # Nothing to check. Merging the pull request is enough.
-
-      # END: Check practical exercise
-
-      - name: Fail job if not all checks passed
-        if: contains(steps.*.outcome, 'failure')
-        run: exit 1
-
   post_review_content:
     name: Post review content
     needs: [find_exercise]


### PR DESCRIPTION
This pull request removes the `check_step_work` job from the `.github/workflows/6-copilot-on-github.yml` workflow file. This job previously handled checking step work and updating issue comments, but is no longer needed.